### PR TITLE
ExperienceScreen: Introduce "Auto" time display option

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceScreen.kt
@@ -139,7 +139,7 @@ fun OneExperienceScreen(
         navigateToURL = navigateToURL,
         navigateToEditRatingScreen = navigateToEditRatingScreen,
         navigateToEditTimedNoteScreen = navigateToEditTimedNoteScreen,
-        timeDisplayOption = viewModel.timeDisplayOptionFlow.collectAsState().value,
+        rawTimeDisplayOption = viewModel.timeDisplayOptionFlow.collectAsState().value,
         onChangeTimeDisplayOption = viewModel::saveTimeDisplayOption,
         navigateToTimelineScreen = navigateToTimelineScreen
     )
@@ -168,7 +168,7 @@ fun ExperienceScreenPreview(
             navigateToURL = {},
             navigateToEditRatingScreen = {},
             navigateToEditTimedNoteScreen = {},
-            timeDisplayOption = TimeDisplayOption.RELATIVE_TO_START,
+            rawTimeDisplayOption = TimeDisplayOption.RELATIVE_TO_START,
             onChangeTimeDisplayOption = {},
             navigateToTimelineScreen = {}
         )
@@ -191,10 +191,19 @@ fun OneExperienceScreen(
     saveIsFavorite: (Boolean) -> Unit,
     navigateToEditRatingScreen: (ratingId: Int) -> Unit,
     navigateToEditTimedNoteScreen: (timedNoteId: Int) -> Unit,
-    timeDisplayOption: TimeDisplayOption,
+    rawTimeDisplayOption: TimeDisplayOption,
     onChangeTimeDisplayOption: (TimeDisplayOption) -> Unit,
     navigateToTimelineScreen: (consumerName: String) -> Unit,
     ) {
+    val timeDisplayOption = if (rawTimeDisplayOption == TimeDisplayOption.AUTO) {
+        if (oneExperienceScreenModel.isShowingAddIngestionButton) {
+            TimeDisplayOption.RELATIVE_TO_NOW
+        } else {
+            TimeDisplayOption.RELATIVE_TO_START
+        }
+    } else {
+        rawTimeDisplayOption
+    }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -202,11 +211,7 @@ fun OneExperienceScreen(
                 actions = {
                     var areTimeOptionsExpanded by remember { mutableStateOf(false) }
                     IconButton(onClick = { areTimeOptionsExpanded = true }) {
-                        if (timeDisplayOption == TimeDisplayOption.REGULAR) {
-                            Icon(Icons.Outlined.Timer, contentDescription = "Time Regular")
-                        } else {
-                            Icon(Icons.Filled.Timer, contentDescription = "Regular Time")
-                        }
+                        Icon(Icons.Outlined.Timer, contentDescription = "Time Display Option")
                     }
                     DropdownMenu(
                         expanded = areTimeOptionsExpanded,
@@ -220,7 +225,7 @@ fun OneExperienceScreen(
                                     areTimeOptionsExpanded = false
                                 },
                                 leadingIcon = {
-                                    if (option == timeDisplayOption) {
+                                    if (option == rawTimeDisplayOption) {
                                         Icon(
                                             Icons.Filled.Check,
                                             contentDescription = "Check",

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
@@ -79,6 +78,7 @@ import com.isaakhanimann.journal.ui.tabs.journal.experience.components.CardTitle
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.CumulativeDoseRow
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.ExperienceEffectTimelines
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.InteractionRow
+import com.isaakhanimann.journal.ui.tabs.journal.experience.components.SavedTimeDisplayOption
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.TimeDisplayOption
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.ingestion.IngestionRow
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.rating.RatingRow
@@ -116,7 +116,7 @@ fun OneExperienceScreen(
             ?: experience?.sortDate ?: Instant.now(),
         notes = experience?.text ?: "",
         locationName = experience?.location?.name ?: "",
-        isShowingAddIngestionButton = viewModel.isShowingAddIngestionButtonFlow.collectAsState().value,
+        isCurrentExperience = viewModel.isCurrentExperienceFlow.collectAsState().value,
         ingestionElements = viewModel.ingestionElementsFlow.collectAsState().value,
         cumulativeDoses = viewModel.cumulativeDosesFlow.collectAsState().value,
         interactions = viewModel.interactionsFlow.collectAsState().value,
@@ -139,7 +139,8 @@ fun OneExperienceScreen(
         navigateToURL = navigateToURL,
         navigateToEditRatingScreen = navigateToEditRatingScreen,
         navigateToEditTimedNoteScreen = navigateToEditTimedNoteScreen,
-        rawTimeDisplayOption = viewModel.timeDisplayOptionFlow.collectAsState().value,
+        savedTimeDisplayOption = viewModel.savedTimeDisplayOption.collectAsState().value,
+        timeDisplayOption = viewModel.timeDisplayOptionFlow.collectAsState().value,
         onChangeTimeDisplayOption = viewModel::saveTimeDisplayOption,
         navigateToTimelineScreen = navigateToTimelineScreen
     )
@@ -168,7 +169,8 @@ fun ExperienceScreenPreview(
             navigateToURL = {},
             navigateToEditRatingScreen = {},
             navigateToEditTimedNoteScreen = {},
-            rawTimeDisplayOption = TimeDisplayOption.RELATIVE_TO_START,
+            savedTimeDisplayOption = SavedTimeDisplayOption.RELATIVE_TO_START,
+            timeDisplayOption = TimeDisplayOption.RELATIVE_TO_START,
             onChangeTimeDisplayOption = {},
             navigateToTimelineScreen = {}
         )
@@ -191,19 +193,11 @@ fun OneExperienceScreen(
     saveIsFavorite: (Boolean) -> Unit,
     navigateToEditRatingScreen: (ratingId: Int) -> Unit,
     navigateToEditTimedNoteScreen: (timedNoteId: Int) -> Unit,
-    rawTimeDisplayOption: TimeDisplayOption,
-    onChangeTimeDisplayOption: (TimeDisplayOption) -> Unit,
+    savedTimeDisplayOption: SavedTimeDisplayOption,
+    timeDisplayOption: TimeDisplayOption,
+    onChangeTimeDisplayOption: (SavedTimeDisplayOption) -> Unit,
     navigateToTimelineScreen: (consumerName: String) -> Unit,
     ) {
-    val timeDisplayOption = if (rawTimeDisplayOption == TimeDisplayOption.AUTO) {
-        if (oneExperienceScreenModel.isShowingAddIngestionButton) {
-            TimeDisplayOption.RELATIVE_TO_NOW
-        } else {
-            TimeDisplayOption.RELATIVE_TO_START
-        }
-    } else {
-        rawTimeDisplayOption
-    }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -217,7 +211,7 @@ fun OneExperienceScreen(
                         expanded = areTimeOptionsExpanded,
                         onDismissRequest = { areTimeOptionsExpanded = false }
                     ) {
-                        TimeDisplayOption.values().forEach { option ->
+                        SavedTimeDisplayOption.values().forEach { option ->
                             DropdownMenuItem(
                                 text = { Text(option.text) },
                                 onClick = {
@@ -225,7 +219,7 @@ fun OneExperienceScreen(
                                     areTimeOptionsExpanded = false
                                 },
                                 leadingIcon = {
-                                    if (option == rawTimeDisplayOption) {
+                                    if (option == savedTimeDisplayOption) {
                                         Icon(
                                             Icons.Filled.Check,
                                             contentDescription = "Check",
@@ -383,7 +377,7 @@ fun OneExperienceScreen(
             )
         },
         floatingActionButton = {
-            if (oneExperienceScreenModel.isShowingAddIngestionButton) {
+            if (oneExperienceScreenModel.isCurrentExperience) {
                 ExtendedFloatingActionButton(
                     onClick = addIngestion,
                     icon = {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceScreenPreviewProvider.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceScreenPreviewProvider.kt
@@ -19,7 +19,13 @@
 package com.isaakhanimann.journal.ui.tabs.journal.experience
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import com.isaakhanimann.journal.data.room.experiences.entities.*
+import com.isaakhanimann.journal.data.room.experiences.entities.AdaptiveColor
+import com.isaakhanimann.journal.data.room.experiences.entities.Ingestion
+import com.isaakhanimann.journal.data.room.experiences.entities.ShulginRating
+import com.isaakhanimann.journal.data.room.experiences.entities.ShulginRatingOption
+import com.isaakhanimann.journal.data.room.experiences.entities.StomachFullness
+import com.isaakhanimann.journal.data.room.experiences.entities.SubstanceCompanion
+import com.isaakhanimann.journal.data.room.experiences.entities.TimedNote
 import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWithCompanion
 import com.isaakhanimann.journal.data.substances.AdministrationRoute
 import com.isaakhanimann.journal.data.substances.classes.InteractionType
@@ -27,7 +33,11 @@ import com.isaakhanimann.journal.data.substances.classes.roa.DurationRange
 import com.isaakhanimann.journal.data.substances.classes.roa.DurationUnits
 import com.isaakhanimann.journal.data.substances.classes.roa.RoaDuration
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.interactions.Interaction
-import com.isaakhanimann.journal.ui.tabs.journal.experience.models.*
+import com.isaakhanimann.journal.ui.tabs.journal.experience.models.ConsumerWithIngestions
+import com.isaakhanimann.journal.ui.tabs.journal.experience.models.CumulativeDose
+import com.isaakhanimann.journal.ui.tabs.journal.experience.models.IngestionElement
+import com.isaakhanimann.journal.ui.tabs.journal.experience.models.InteractionExplanation
+import com.isaakhanimann.journal.ui.tabs.journal.experience.models.OneExperienceScreenModel
 import com.isaakhanimann.journal.ui.utils.getInstant
 
 class OneExperienceScreenPreviewProvider :
@@ -46,7 +56,7 @@ class OneExperienceScreenPreviewProvider :
             )!!,
             notes = "Some Notes",
             locationName = "Zurich",
-            isShowingAddIngestionButton = true,
+            isCurrentExperience = true,
             ingestionElements = ingestionElements,
             cumulativeDoses = listOf(
                 CumulativeDose(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeDisplayOption.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeDisplayOption.kt
@@ -19,7 +19,9 @@
 package com.isaakhanimann.journal.ui.tabs.journal.experience.components
 
 enum class TimeDisplayOption {
-    RELATIVE_TO_NOW {
+    AUTO {
+        override val text = "Auto"
+    }, RELATIVE_TO_NOW {
         override val text = "Time Relative To Now"
     }, RELATIVE_TO_START {
         override val text = "Time Relative To Start"

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeDisplayOption.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeDisplayOption.kt
@@ -18,7 +18,7 @@
 
 package com.isaakhanimann.journal.ui.tabs.journal.experience.components
 
-enum class TimeDisplayOption {
+enum class SavedTimeDisplayOption {
     AUTO {
         override val text = "Auto"
     }, RELATIVE_TO_NOW {
@@ -30,4 +30,9 @@ enum class TimeDisplayOption {
     };
 
     abstract val text: String
+}
+
+
+enum class TimeDisplayOption {
+    RELATIVE_TO_NOW , RELATIVE_TO_START, REGULAR;
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeRelativeToStartText.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeRelativeToStartText.kt
@@ -37,10 +37,10 @@ fun TimeRelativeToStartText(
 ) {
     val duration = Duration.between(startTime, time)
     val relativeTime = when {
-        duration.toDays() > 3 -> "${duration.toDays()} days"
-        duration.toHours() > 24 -> "${roundToOneDecimal(duration.toHours().toDouble()/24.0)} days"
-        duration.toHours() > 1 -> "${roundToOneDecimal(duration.toMinutes().toDouble()/60.0)} hours"
-        duration.toMinutes() > 0 -> "${duration.toMinutes()} minutes"
+        duration.toDays() > 3 -> "${duration.toDays()} days in"
+        duration.toHours() > 24 -> "${roundToOneDecimal(duration.toHours().toDouble()/24.0)} days in"
+        duration.toHours() > 1 -> "${roundToOneDecimal(duration.toMinutes().toDouble()/60.0)} hours in"
+        duration.toMinutes() > 0 -> "${duration.toMinutes()} minutes in"
         else -> "Start"
     }
     Text(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeRelativeToStartText.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeRelativeToStartText.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.isaakhanimann.journal.ui.tabs.journal.components.roundToOneDecimal
+import com.isaakhanimann.journal.ui.utils.getStringOfPattern
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -41,7 +42,9 @@ fun TimeRelativeToStartText(
         duration.toHours() > 24 -> "${roundToOneDecimal(duration.toHours().toDouble()/24.0)} days in"
         duration.toHours() > 1 -> "${roundToOneDecimal(duration.toMinutes().toDouble()/60.0)} hours in"
         duration.toMinutes() > 0 -> "${duration.toMinutes()} minutes in"
-        else -> "Start"
+        duration.toMillis() > 0 -> "${(duration.toMillis()/1000).toInt()} seconds in"
+        else -> time.getStringOfPattern("EEE HH:mm")
+
     }
     Text(
         text = relativeTime,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeText.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeText.kt
@@ -52,6 +52,5 @@ fun TimeText(
                 style = style
             )
         }
-        else -> {}
     }
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeText.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeText.kt
@@ -52,5 +52,6 @@ fun TimeText(
                 style = style
             )
         }
+        else -> {}
     }
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/models/OneExperienceScreenModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/models/OneExperienceScreenModel.kt
@@ -29,7 +29,7 @@ data class OneExperienceScreenModel(
     val firstIngestionTime: Instant,
     val notes: String,
     val locationName: String,
-    val isShowingAddIngestionButton: Boolean,
+    val isCurrentExperience: Boolean,
     val ingestionElements: List<IngestionElement>,
     val cumulativeDoses: List<CumulativeDose>,
     val interactions: List<Interaction>,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
@@ -22,7 +22,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import com.isaakhanimann.journal.ui.tabs.journal.experience.components.TimeDisplayOption
+import com.isaakhanimann.journal.ui.tabs.journal.experience.components.SavedTimeDisplayOption
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -34,16 +34,16 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
         val KEY_TIME_DISPLAY_OPTION = stringPreferencesKey("key_time_display_option")
     }
 
-    suspend fun saveTimeDisplayOption(value: TimeDisplayOption) {
+    suspend fun saveTimeDisplayOption(value: SavedTimeDisplayOption) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.KEY_TIME_DISPLAY_OPTION] = value.name
         }
     }
 
-    val timeDisplayOptionFlow: Flow<TimeDisplayOption> = dataStore.data
+    val savedTimeDisplayOptionFlow: Flow<SavedTimeDisplayOption> = dataStore.data
         .map { preferences ->
-            val name = preferences[PreferencesKeys.KEY_TIME_DISPLAY_OPTION] ?: TimeDisplayOption.REGULAR.name
-            TimeDisplayOption.valueOf(name)
+            val name = preferences[PreferencesKeys.KEY_TIME_DISPLAY_OPTION] ?: SavedTimeDisplayOption.REGULAR.name
+            SavedTimeDisplayOption.valueOf(name)
         }
 }
 


### PR DESCRIPTION
IMO during an ongoing experience one would want to check the time since consumption, while for a long completed experience the time relative to the start probably makes more sense. This PR introduces a new "Auto" setting which accomplishes exactly this.

IDK about the second commit, there seems to be no concise way properly express "x minutes after the start of the experience".