### PR TITLE
Build release pipeline

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,7 +34,7 @@ jobs:
           signingKey: ${{ secrets.KEYSTORE }}
           keyAlias: ${{ secrets.SIGNING_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.SIGNING_STORE_PASSWORD }}
-          keyPassword: ${{ secrets.KEY_PASSWORD }}
+          keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
           buildToolsVersion: 35.0.0
 
       - name: Rename signed APK

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,59 @@
+name: Build App on new release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*'
+
+jobs:
+  build:
+    name: Build, sign and release app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up jdk
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "17"
+          cache: "gradle"
+
+      - name: build app
+        run: ./gradlew assembleRelease --no-daemon
+
+      - name: Setup Android SDK
+        run: |
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"
+
+      - name: Sign app APK
+        uses: ilharp/sign-android-release@nightly
+        id: sign
+        with:
+          signingKey: ${{ secrets.KEYSTORE }}
+          keyAlias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+          buildToolsVersion: 35.0.0
+
+      - name: Rename signed APK
+        run: |
+          mv "${{steps.sign.outputs.signedFile}}" "psychonautwiki-journal_${{ github.ref_name }}.apk"
+
+      # Uploads to the action results if not pointed at a tag
+      - uses: actions/upload-artifact@v4
+        if: "! startsWith(github.ref, 'refs/tags/')"
+        with:
+          name: "psychonautwiki-journal_${{ github.ref_name }}.apk"
+          path: "psychonautwiki-journal_${{ github.ref_name }}.apk"
+          if-no-files-found: error
+
+      # Creates a release if pointed at a tag
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "psychonautwiki-journal_${{ github.ref_name }}.apk"
+          fail_on_unmatched_files: true
+          make_latest: true


### PR DESCRIPTION
Hello,
This PR adds a github action to automatically build, sign and release the app when a new tag is pushed. This allows users to directly download the app from the github releases page. I also want to create an F-droid release based on this. To make this pipeline work there are a few github secrets which need to be created:
 - KEYSTORE
   is a base64 encoded version of the keystore used to sign the app. You can create one using this one-liner:
  ```bash
openssl base64 < some_signing_key.jks | tr -d '\n' | tee some_signing_key.jks.base64.txt
```
(Taken from [here](https://github.com/ilharp/sign-android-release#inputs))
 - SIGNING_STORE_PASSWORD
    The password for the keystore 
 - SIGNING_KEY_ALIAS
   The alias of the key
 - SIGNING_KEY_PASSWORD
   Optionally if the key has a password

It would be great if the github signing key could be the same one as the one used to sign playstore releases, since that would allow users to seamlessly switch between the different distribution methods.

Please don't hesitate to ask questions about this :)