### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Android SDK
         run: |
-          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0"
 
       - name: Sign app APK
         uses: ilharp/sign-android-release@nightly
@@ -37,7 +37,7 @@ jobs:
           keyAlias: ${{ secrets.SIGNING_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.SIGNING_STORE_PASSWORD }}
           keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          buildToolsVersion: 35.0.0
+          buildToolsVersion: 34.0.0
 
       - name: Rename signed APK
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build, sign and release app
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fixes the CI Permission issue, see these references for more info:
 - https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 - https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions

Also switched the android sdk to the version from build.gradle to facilitate reproducible builds (Needed to publish developer-signed apps on F-Droid)